### PR TITLE
Update hwmon-it87-9999.ebuild

### DIFF
--- a/sys-apps/hwmon-it87/hwmon-it87-9999.ebuild
+++ b/sys-apps/hwmon-it87/hwmon-it87-9999.ebuild
@@ -14,7 +14,7 @@ SLOT="0"
 KEYWORDS="amd64 ~x86"
 IUSE=""
 
-DEPEND="sys-apps/lm_sensors"
+DEPEND="sys-apps/lm-sensors"
 RDEPEND="${DEPEND}"
 BDEPEND=""
 


### PR DESCRIPTION
Gnetoo has sys-apps/lm-sensors package instead of sys-apps/lm_sensors.